### PR TITLE
Create derived time

### DIFF
--- a/code/assignTime.m
+++ b/code/assignTime.m
@@ -84,7 +84,7 @@ packetsToRemove = unique([badDatePackets; packetIndices_NegGenTime;...
 % Remove packets identified above for rejection
 packetsToKeep = setdiff(1:size(dataTable_original,1),packetsToRemove);
 dataTable = dataTable_original(packetsToKeep,:);
-
+clear dataTable_original
 %%
 % Identify gaps -- start with most obvious gaps, and then become more
 % refined
@@ -216,6 +216,7 @@ correctedAlignTime_shifted = correctedAlignTime(1) + (multiples * deltaTime);
 
 % Full form data table
 outputDataTable = inputDataTable;
+clear inputDataTable
 
 % Remove packets and samples identified above as lacking proper metadata
 samplesToRemove = [];

--- a/code/assignTime.m
+++ b/code/assignTime.m
@@ -275,26 +275,6 @@ end
 disp('Cleaning up output table')
 outputDataTable.DerivedTime = DerivedTime;
 rowsToRemove = find(DerivedTime == 0);
-outputDataTable.DerivedTime = nan(size(outputDataTable,1),1);
-for iChunk = 1:length(chunkIndices)
-    % Display status
-    if iChunk > 0 && mod(iChunk, 1000) == 0
-        disp(['Currently on chunk ' num2str(iChunk) ' of ' num2str(length(chunkIndices))])
-    end
-    % Assign derivedTimes to all samples (from before first packet time to end) -- all same
-    % sampling rate
-    currentFs = outputDataTable.samplerate(chunkPacketStart(iChunk));
-    elapsedTime_before = (chunkPacketStart(iChunk) - chunkSampleStart(iChunk)) * (1000/currentFs);
-    elapsedTime_after = (chunkSampleEnd(iChunk) - chunkPacketStart(iChunk)) * (1000/currentFs);
-    
-    outputDataTable.DerivedTime(chunkSampleStart(iChunk):chunkSampleEnd(iChunk)) = ...
-        correctedAlignTime_shifted(iChunk) - elapsedTime_before : 1000/currentFs : correctedAlignTime_shifted(iChunk) + elapsedTime_after;
-end
-
-% All samples which do not have a derivedTime should be removed from final
-% data table
-disp('Cleaning up output table')
-rowsToRemove = find(outputDataTable.DerivedTime == 0);
 outputDataTable(rowsToRemove,:) = [];
 
 end

--- a/code/assignTime.m
+++ b/code/assignTime.m
@@ -254,6 +254,27 @@ disp('Creating derivedTime for each sample')
 % derivedTime
 
 % Initalize DerivedTime
+DerivedTime = nan(size(outputDataTable,1),1);
+for iChunk = 1:length(chunkIndices)
+    % Display status
+    if iChunk > 0 && mod(iChunk, 1000) == 0
+        disp(['Currently on chunk ' num2str(iChunk) ' of ' num2str(length(chunkIndices))])
+    end
+    % Assign derivedTimes to all samples (from before first packet time to end) -- all same
+    % sampling rate
+    currentFs = outputDataTable.samplerate(chunkPacketStart(iChunk));
+    elapsedTime_before = (chunkPacketStart(iChunk) - chunkSampleStart(iChunk)) * (1000/currentFs);
+    elapsedTime_after = (chunkSampleEnd(iChunk) - chunkPacketStart(iChunk)) * (1000/currentFs);
+    
+    DerivedTime(chunkSampleStart(iChunk):chunkSampleEnd(iChunk)) = ...
+        correctedAlignTime_shifted(iChunk) - elapsedTime_before : 1000/currentFs : correctedAlignTime_shifted(iChunk) + elapsedTime_after;
+end
+
+% All samples which do not have a derivedTime should be removed from final
+% data table
+disp('Cleaning up output table')
+outputDataTable.DerivedTime = DerivedTime;
+rowsToRemove = find(DerivedTime == 0);
 outputDataTable.DerivedTime = nan(size(outputDataTable,1),1);
 for iChunk = 1:length(chunkIndices)
     % Display status

--- a/code/assignTime.m
+++ b/code/assignTime.m
@@ -112,6 +112,7 @@ indices_dataTypeSequenceFlagged = intersect(find(diff(dataTable.dataTypeSequence
 % 'previous' to 'current' packets; diff_systemTick written to index of
 % second packet associated with that calculation
 numPackets = size(dataTable,1);
+diff_systemTick = nan(numPackets,1);
 for iPacket = 2:numPackets
     diff_systemTick(iPacket,1) = mod((dataTable.systemTick(iPacket) + (2^16)...
         - dataTable.systemTick(iPacket - 1)), 2^16);

--- a/code/assignTime.m
+++ b/code/assignTime.m
@@ -253,6 +253,10 @@ disp('Creating derivedTime for each sample')
 % Initalize DerivedTime
 outputDataTable.DerivedTime = nan(size(outputDataTable,1),1);
 for iChunk = 1:length(chunkIndices)
+    % Display status
+    if iChunk > 0 && mod(iChunk, 1000) == 0
+        disp(['Currently on chunk ' num2str(iChunk) ' of ' num2str(length(chunkIndices))])
+    end
     % Assign derivedTimes to all samples (from before first packet time to end) -- all same
     % sampling rate
     currentFs = outputDataTable.samplerate(chunkPacketStart(iChunk));

--- a/code/assignTime.m
+++ b/code/assignTime.m
@@ -1,0 +1,268 @@
+function timeDomainData = assignTime(outtable_TD)
+%%
+% Function for creating timestamps for each sample of valid RC+S data. Given
+% known limitations of all recorded timestamps, need to use multiple variables
+% to derive time.
+%
+% General approach: Remove packets with faulty meta-data.
+% Identify gaps in data (by checking deltas in timestamp, systemTick,
+% and dataTypeSequence). Consecutive packets of data without gaps
+% are referred to as 'chunks'. For each chunk, determine best estimate of
+% the first packet time, and then calculate time for each  sample based on
+% sampling rate -- assume no missing samples. Best estimate of start time
+% for each chunk is determined by taking median (across all packets in that
+% chunk) of the offset between delta PacketGenTime and expected time to
+% have elapsed (as a function of sampling rate and number of samples
+% per packet).
+%
+% Input: Data table output from unravelData (data originating from RawDataTD.json)
+%
+% Output: Same as input table, with additional column of 'DerivedTimes' for
+% each sample
+%%
+
+% Pull out info for each packet
+indicesOfTimestamps = find(outtable_TD.timestamp ~= 0);
+dataTable_original = outtable_TD(indicesOfTimestamps,:);
+
+%%
+% Identify packets for rejection
+
+% Remove any packets with timestamp that are more than 24 hours from median timestamp
+medianTimestamp = median(dataTable_original.timestamp);
+numSecs = 24*60*60;
+badDatePackets = union(find(dataTable_original.timestamp > medianTimestamp + numSecs),find(dataTable_original.timestamp < medianTimestamp - numSecs));
+
+% Negative PacketGenTime
+packetIndices_NegGenTime = find(dataTable_original.PacketGenTime <= 0);
+
+% Consecutive packets with identical dataTypeSequence and systemTick;
+% identify the second packet for removal; identify the first
+% instance of these duplicates below
+duplicate_firstIndex = intersect(find(diff(dataTable_original.dataTypeSequence) == 0),...
+    find(diff(dataTable_original.systemTick) == 0));
+
+% Packets with outlier PacketGenTime, as determined by differences between
+% timestamp and PacketGenTime. This does not address packets which have
+% both 'bad' timestamp and PacketGenTime. Packets with only bad timestamp
+% may also be flagged
+normedTimestamps = dataTable_original.timestamp - dataTable_original(1,:).timestamp;
+normedGenTime_inSecs = (dataTable_original.PacketGenTime - dataTable_original(1,:).PacketGenTime)/1000;
+
+timeDifferences = normedTimestamps - normedGenTime_inSecs;
+indices_outlierPacketGenTimes = find(abs(timeDifferences) > 1);
+
+% Identify packetGenTimes that go backwards in time; should overlap with negative PacketGenTime
+packetGenTime_diffs = diff(dataTable_original.PacketGenTime);
+diffIndices = find(packetGenTime_diffs < 0 );
+
+% Need to remove [diffIndices + 1], but may also need to remove subsequent
+% packets. Remove at most 5 adjacent packets (to prevent large un-needed
+% packet rejection driven by positive outliers)
+indices_backInTime = [];
+for iIndex = 1:length(diffIndices)
+    counter = 1;
+    while (counter < 6) && dataTable_original.PacketGenTime(diffIndices(iIndex) + counter)...
+            < dataTable_original.PacketGenTime(diffIndices(iIndex))
+        
+        indices_backInTime = [indices_backInTime (diffIndices(iIndex) + counter)];
+        counter = counter + 1;
+    end
+end
+
+% Collect all packets to remove
+packetsToRemove = unique([badDatePackets; packetIndices_NegGenTime;...
+    duplicate_firstIndex + 1; indices_outlierPacketGenTimes; indices_backInTime']);
+
+% Remove packets identified above for rejection
+packetsToKeep = setdiff(1:size(dataTable_original,1),packetsToRemove);
+dataTable = dataTable_original(packetsToKeep,:);
+
+%%
+% Identify gaps -- start with most obvious gaps, and then become more
+% refined
+
+% Change in sampling rate should start a new chunk; identify indices of
+% last packet of a chunk
+if ~isequal(length(unique(dataTable.samplerate)),1)
+    indices_changeFs = find(diff(dataTable.samplerate) ~=0);
+else
+    indices_changeFs = [];
+end
+maxFs = max(unique(dataTable.samplerate));
+
+% Timestamp difference from previous packet not 0 or 1 -- indicates gap or
+% other abnormality; these indices indicate the end of a continuous chunk
+indices_timestampFlagged = intersect(find(diff(dataTable.timestamp) ~= 0),find(diff(dataTable.timestamp) ~= 1));
+
+% Instances where dataTypeSequence doesn't iterate by 1; these indices
+% indicate the end of a continuous chunk
+indices_dataTypeSequenceFlagged = intersect(find(diff(dataTable.dataTypeSequence) ~= 1),find(diff(dataTable.dataTypeSequence) ~= -255));
+
+% Lastly, check systemTick to ensure there are no packets missing.
+% Determine delta time between systemTicks in adjacent packets.
+% Exclude first packet from those to test, because need to compare times from
+% 'previous' to 'current' packets; diff_systemTick written to index of
+% second packet associated with that calculation
+numPackets = size(dataTable,1);
+for iPacket = 2:numPackets
+    diff_systemTick(iPacket,1) = mod((dataTable.systemTick(iPacket) + (2^16)...
+        - dataTable.systemTick(iPacket - 1)), 2^16);
+end
+
+% Expected elapsed time for each packet, based on sample rate and number of
+% samples per packet; in units of systemTick (1e-4 seconds)
+expectedElapsed = dataTable.packetsizes .* (1./dataTable.samplerate) * 1e4;
+
+% If diff_systemTick and expectedElapsed differ by more than 10% of expectedElapsed,
+% flag as gap
+indices_systemTickFlagged = find (abs(expectedElapsed(2:end) - diff_systemTick(2:end)) > 0.1*expectedElapsed(2:end));
+
+% All packets flagged as end of continuous chunks
+allFlaggedIndices = unique([indices_changeFs; indices_timestampFlagged;...
+    indices_dataTypeSequenceFlagged; indices_systemTickFlagged],'sorted') ;
+
+%%
+% Determine indices of packets which correspond to each data chunk
+if ~isempty(allFlaggedIndices)
+    counter = 1;
+    chunkIndices = cell(1,length(allFlaggedIndices) + 1);
+    for iChunk = 1:length(allFlaggedIndices)
+        if iChunk == 1
+            chunkIndices{counter} = (1:allFlaggedIndices(1));
+            currentStartIndex = 1;
+            counter = counter + 1;
+        else
+            chunkIndices{counter} = allFlaggedIndices(currentStartIndex) + 1:allFlaggedIndices(currentStartIndex + 1);
+            currentStartIndex = currentStartIndex + 1;
+            counter = counter + 1;
+        end
+        % Last chunk, finishing with last packet
+        chunkIndices{counter} = allFlaggedIndices(currentStartIndex) + 1:numPackets;
+    end
+else
+    % No identified missing packets, all packets in one chunk
+    chunkIndices{1} = 1:numPackets;
+end
+
+%%
+% Loop through each chunk to determine offset to apply (as determined by
+% average difference between packetGenTime and expectedElapsed)
+
+% PacketGenTime in ms; convert difference to 1e-4 seconds, units of
+% systemTick and expectedElapsed
+diff_PacketGenTime = [1; diff(dataTable.PacketGenTime) * 1e1];
+
+numChunks = length(chunkIndices);
+chunksToExclude = [];
+for iChunk = 1:numChunks
+    currentTimestampIndices = chunkIndices{iChunk};
+    
+    % Chunks must have at least 2 packets in order to have a valid
+    % diff_systemTick -- thus if chunk only one packet, it must be excluded
+    if length(currentTimestampIndices) == 1
+        chunksToExclude = [chunksToExclude iChunk];
+    end
+    % Always exclude the first packet of the chunk, because don't have an
+    % accurate diff_systemTick value for this first packet
+    currentTimestampIndices = currentTimestampIndices(2:end);
+    
+    % Differences between adjacent PacketGenTimes (in units of 1e-4
+    % seconds)
+    error = expectedElapsed(currentTimestampIndices) - diff_PacketGenTime(currentTimestampIndices);
+    meanError(iChunk) = median(error);
+end
+%%
+% Create corrected timing for each chunk
+for iChunk = 1:numChunks
+    if ~ismember(iChunk,chunksToExclude)
+        alignTime(iChunk) = dataTable.PacketGenTime(chunkIndices{iChunk}(1));
+    end
+end
+
+% alignTime in ms; meanError in units of systemTick
+correctedAlignTime = alignTime + meanError*1e-1;
+% TO DO: add or subtract meanError above??
+
+%%
+% Indices in chunkIndices correspond to packets in dataTable.
+% CorrectedAlignTime corresponds to first packet for each chunk in
+% chunkIndices. Remove chunks identified above
+chunkIndices(chunksToExclude) = [];
+correctedAlignTime(find(isnan(correctedAlignTime))) = [];
+
+% correctedAlignTime is shifted slightly to keep times exactly aligned to
+% sampling rate; use maxFs for alignment points. In other words, take first
+% correctedAlignTime, and place all other correctedAlignTimes at multiples of
+% (1/Fs)
+deltaTime = 1/maxFs * 1000; % in milliseconds
+
+allPossibleTimes = correctedAlignTime(1):deltaTime:correctedAlignTime(end) + deltaTime;
+correctedAlignTime_shifted = NaN(size(correctedAlignTime));
+correctedAlignTime_shifted(1) = correctedAlignTime(1);
+for iTime = 2:length(correctedAlignTime)
+    currentTime = correctedAlignTime(iTime);
+    [value, indexOfPossibleTimes] = ( min(abs(currentTime - allPossibleTimes)));
+    correctedAlignTime_shifted(iTime) = allPossibleTimes(indexOfPossibleTimes);
+end
+
+% Full form data table
+timeDomainData = outtable_TD;
+
+% Remove packets and samples identified above as lacking proper metadata
+samplesToRemove = [];
+% If first packet is included, collect those samples separately
+if ismember(1,packetsToRemove)
+    samplesToRemove = 1:indicesOfTimestamps(1);
+    packetsToRemove = setdiff(packetsToRemove,1);
+end
+% Loop through all other packetsToRemove
+toRemove_start = indicesOfTimestamps(packetsToRemove - 1) + 1;
+toRemove_stop = indicesOfTimestamps(packetsToRemove);
+for iPacket = 1:length(packetsToRemove)
+    samplesToRemove = [samplesToRemove toRemove_start(iPacket):toRemove_stop(iPacket)];
+end
+timeDomainData(samplesToRemove,:) = [];
+
+% Indices referenced in chunkIndices can now be mapped back to timeDomainData
+% using indicesOfTimestamps_cleaned
+indicesOfTimestamps_cleaned = find(timeDomainData.timestamp ~= 0);
+
+% Map the chunk start/stop times back to samples
+for iChunk = 1:length(chunkIndices)
+    currentPackets = chunkIndices{iChunk};
+    chunkPacketStart(iChunk) = indicesOfTimestamps_cleaned(currentPackets(1));
+    if currentPackets(1) == 1 % First packet, thus take first sample
+        chunkSampleStart(iChunk) = 1;
+    else
+        chunkSampleStart(iChunk) = indicesOfTimestamps_cleaned(currentPackets(1) - 1) + 1;
+    end
+    chunkSampleEnd(iChunk) = indicesOfTimestamps_cleaned(currentPackets(end));
+end
+
+% Use correctedAlignTime and sampling rate to assign each included sample a
+% derivedTime
+for iChunk = 1:length(chunkIndices)
+    % Assign derivedTimes to samples before first packet time -- all same
+    % sampling rate
+    currentFs = timeDomainData.samplerate(chunkPacketStart(iChunk));
+    elapsedTime_before = (chunkPacketStart(iChunk) - chunkSampleStart(iChunk)) * (1000/currentFs);
+    
+    timeDomainData.DerivedTime(chunkPacketStart(iChunk):-1:chunkSampleStart(iChunk)) = ...
+        correctedAlignTime_shifted(iChunk) : -1000/currentFs : correctedAlignTime_shifted(iChunk) - elapsedTime_before;
+    
+    % Assign derivedTimes to samples after first packetTime -- all same
+    % sampling rate (as change in Fs triggered creation of new chunk, above)
+    elapsedTime_after = (chunkSampleEnd(iChunk) - chunkPacketStart(iChunk) + 1) * (1000/currentFs);
+    
+    timeDomainData.DerivedTime(chunkPacketStart(iChunk) + 1 : chunkSampleEnd(iChunk)) = ...
+        correctedAlignTime_shifted(iChunk) + (1000/currentFs) : 1000/currentFs : correctedAlignTime_shifted(iChunk) + elapsedTime_after - (1000/currentFs);
+end
+
+% All samples which do not have a derivedTime should be removed from final
+% timeDomainData table
+
+rowsToRemove = find(timeDomainData.DerivedTime == 0);
+timeDomainData(rowsToRemove,:) = [];
+
+end

--- a/code/assignTime.m
+++ b/code/assignTime.m
@@ -140,14 +140,15 @@ if ~isempty(allFlaggedIndices)
             chunkIndices{counter} = (1:allFlaggedIndices(1));
             currentStartIndex = 1;
             counter = counter + 1;
+        elseif iChunk == length(allFlaggedIndices)
+            chunkIndices{counter} = allFlaggedIndices(currentStartIndex) + 1:allFlaggedIndices(currentStartIndex + 1);
+            chunkIndices{counter + 1} = allFlaggedIndices(currentStartIndex + 1) + 1:numPackets;
         else
             chunkIndices{counter} = allFlaggedIndices(currentStartIndex) + 1:allFlaggedIndices(currentStartIndex + 1);
             currentStartIndex = currentStartIndex + 1;
             counter = counter + 1;
         end
-        % Last chunk, finishing with last packet
-        chunkIndices{counter} = allFlaggedIndices(currentStartIndex) + 1:numPackets;
-    end
+     end
 else
     % No identified missing packets, all packets in one chunk
     chunkIndices{1} = 1:numPackets;

--- a/code/createAccelTable.m
+++ b/code/createAccelTable.m
@@ -13,7 +13,7 @@ dataSizes = [tmp.dataSize]';
 packetSizes = (dataSizes/8); % divide by 8 for now, this may need to be fixed
 nrows = sum(packetSizes);
 
-allVarNames = {'XSamples','YSamples','ZSamples','systemTick','timestamp','PacketGenTime',...
+allVarNames = {'XSamples','YSamples','ZSamples','systemTick','timestamp','samplerate','PacketGenTime',...
     'PacketRxUnixTime','packetsizes','dataTypeSequence'};
 % Pre allocate memory
 outdat = zeros(nrows, length(allVarNames));
@@ -31,10 +31,11 @@ for p = 1:size(dataSizes,1)
     outdat(rowidx, 3) = jsonobj_Accel.AccelData(p).ZSamples;
     outdat(packetidx, 4) = jsonobj_Accel.AccelData(p).Header.systemTick;
     outdat(packetidx, 5) = jsonobj_Accel.AccelData(p).Header.timestamp.seconds;
-    outdat(packetidx, 6) = jsonobj_Accel.AccelData(p).PacketGenTime;
-    outdat(packetidx, 7) = jsonobj_Accel.AccelData(p).PacketRxUnixTime;
-    outdat(packetidx, 8) = packetSizes(p);
-    outdat(packetidx, 9) = jsonobj_Accel.AccelData(p).Header.dataTypeSequence;
+    outdat(packetidx, 6) = srates(p);
+    outdat(packetidx, 7) = jsonobj_Accel.AccelData(p).PacketGenTime;
+    outdat(packetidx, 8) = jsonobj_Accel.AccelData(p).PacketRxUnixTime;
+    outdat(packetidx, 9) = packetSizes(p);
+    outdat(packetidx, 10) = jsonobj_Accel.AccelData(p).Header.dataTypeSequence;
 end
 
 %%

--- a/code/createAccelTable.m
+++ b/code/createAccelTable.m
@@ -1,0 +1,198 @@
+function [outtable, srates] = createAccelTable(TDdat)
+%% Function to unravel TimeDomainData
+% input: a structure time domain data that is read from TimeDomainRaw.json 
+% file that is spit out by RC+S Summit interface. 
+% To transform *.json file into structure use deserializeJSON.m 
+% in this folder 
+%% unravel data 
+
+
+
+%% check for bad packets 
+
+unixtimes = [TDdat.AccelData.PacketRxUnixTime];
+uxtimes = datetime(unixtimes'/1000,...
+    'ConvertFrom','posixTime','TimeZone','America/Los_Angeles','Format','dd-MMM-yyyy HH:mm:ss.SSS');
+
+temp  = [TDdat.AccelData.Header];
+temp2 = [temp.timestamp];
+uxseconds = [temp2.seconds];
+startTimeDt = datetime(datevec(uxseconds./86400 + datenum(2000,3,1,0,0,0))); % medtronic time - LSB is seconds
+
+yearMode = mode(year(startTimeDt)); 
+
+
+
+
+% check for packets with funky year 
+badPackets = year(startTimeDt)~=yearMode;  % sometimes the seconds is a bad msseaurment 
+% evidnetly year is not hte only problem, make sure most packets within a
+% week of median (to take care of cases in which reconnecitons happen
+% throughout days) 
+medianTime = median(startTimeDt);
+badPackets3 = startTimeDt > (medianTime + hours(24)*7);
+badPackets4= startTimeDt < (medianTime - hours(24)*7);
+% check for packets in the future 
+badPackets2 = uxtimes(1:end-1) >= uxtimes(2:end) ;
+badPackets2 = [badPackets2; 0];
+% check to see if packet time can be negative 
+badpackets5 = [TDdat.AccelData.PacketGenTime]<=0;
+badpackets5 = badpackets5';
+% check to see if data type sequence always increases monotonically 
+% note that it roles over after 255 packets (e.g. goes from 255 to 0). 
+% I am getting rid of the first packet on purpose 
+headertemp = TDdat.AccelData;
+headers2 = [headertemp.Header];
+dataTypeSequence = [headers2.dataTypeSequence];
+dataTypeSequenceTemp = [headers2(1).dataTypeSequence dataTypeSequence];
+badpackets6 = diff(dataTypeSequenceTemp')==0;
+
+
+idxBadPackets = badPackets | badPackets2 | badPackets3 | badPackets4 | badpackets5 | badpackets6 ;
+TDdat.AccelData = TDdat.AccelData(~idxBadPackets);
+
+
+
+% find ambigous roleovers and remove them to make them not ambigous
+% any more 
+headertemp = TDdat.AccelData;
+headers2 = [headertemp.Header];
+temp = [headers2.timestamp];
+timestamps = [temp.seconds]; 
+timestamps_sec = datetime(datevec(timestamps./86400 + datenum(2000,3,1,0,0,0)),...% medtronic time - LSB is seconds
+    'TimeZone','America/Los_Angeles','Format','dd-MMM-yyyy HH:mm:ss.SSS'); 
+idxGapsLargerThan6sec = find(seconds(diff([timestamps_sec(1); timestamps_sec])) > 6);
+max_st = (2^16)/1e4; 
+cnt = 1;
+bad_timestamps = NaT;
+bad_timestamps.TimeZone = timestamps_sec.TimeZone;
+for i = 1:length( idxGapsLargerThan6sec ) 
+    ts1 = timestamps_sec(idxGapsLargerThan6sec(i)-1); 
+    ts2 = timestamps_sec(idxGapsLargerThan6sec(i)); 
+    curgap = ts2-ts1; 
+    % is the gap potentially ambgious
+    minN = seconds(ts2 - (ts1 + seconds(1))) / max_st;
+    maxN = seconds((ts2+ seconds(1)) - ts1) / max_st;
+    % if the gap can be ambigous remove packets until it is not
+    if floor(minN) ~= floor(maxN) 
+        minN_new = minN; 
+        maxN_new = maxN; 
+        
+        ts2_new = ts2;
+        ts1_new = ts1;
+
+         while minN_new ~= maxN_new
+             minN_new = floor( seconds(ts2_new - (ts1_new + seconds(1))) / max_st );
+             maxN_new = floor( seconds((ts2_new+ seconds(1)) - ts1_new) / max_st  );
+             bad_timestamps(cnt) = ts2_new;
+             ts2_new = ts2_new + seconds(1);
+             cnt = cnt +1 ;
+         end
+         fprintf('[%0.3d] current gap is %s secs\n',i,ts2_new-ts1_new);
+         fprintf('\t ts1   - %s\t ts2   - %s\n',ts1,ts2);
+         fprintf('\t ts1_n - %s\t ts2_n - %s\n',ts1_new,ts2_new);
+    else
+        fprintf('[%0.3d] current gap is not ambigous - %s secs\n',i,ts2-ts1);
+                 fprintf('\t ts1   - %s\t ts2   - %s\n',ts1,ts2);
+
+    end
+end
+idx_bad_timetamps = [];
+for b = 1:length(bad_timestamps)
+    idx_bad_timetamps = [idx_bad_timetamps; find(timestamps_sec == bad_timestamps(b) )];
+end
+idxkeep = setxor(1:size(TDdat.AccelData,2),idx_bad_timetamps);
+
+% repot on the gaps before and after the changes 
+systemTicks = [headers2.systemTick];
+for i = 1:length(idxGapsLargerThan6sec)
+    fprintf('[%0.2d]\t previous = %s\t \t%d  current = %s\t %d\t \n',...
+        i,timestamps_sec(idxGapsLargerThan6sec(i) - 1),systemTicks(idxGapsLargerThan6sec(i)-1)',...
+        timestamps_sec(idxGapsLargerThan6sec(i)),systemTicks(idxGapsLargerThan6sec(i))')
+end
+TDdat.AccelData = TDdat.AccelData(idxkeep);
+
+
+headertemp = TDdat.AccelData;
+headers2 = [headertemp.Header];
+temp = [headers2.timestamp];
+systemTicks = [headers2.systemTick];
+timestamps = [temp.seconds]; 
+timestamps_sec = datetime(datevec(timestamps./86400 + datenum(2000,3,1,0,0,0)),...% medtronic time - LSB is seconds
+    'TimeZone','America/Los_Angeles','Format','dd-MMM-yyyy HH:mm:ss.SSS'); 
+idxGapsLargerThan6sec = find(seconds(diff([timestamps_sec(1); timestamps_sec])) > 6);
+for i = 1:length(idxGapsLargerThan6sec)
+    fprintf('[%0.2d]\t previous = %s\t \t%d  current = %s\t %d\t \n',...
+        i,timestamps_sec(idxGapsLargerThan6sec(i) - 1),systemTicks(idxGapsLargerThan6sec(i)-1)',...
+        timestamps_sec(idxGapsLargerThan6sec(i)),systemTicks(idxGapsLargerThan6sec(i))')
+end
+
+
+
+% remove system ticks that are the same - this is essentially a duplicate
+% packet, remove the second one 
+% there is a small chance we are removing a roleover event (e.g. large
+% packet loss, but even in these cases it would make it much easier to
+% compute if we didn't have this packet). 
+headertemp = TDdat.AccelData;
+headers2 = [headertemp.Header];
+systemTicks = [headers2.systemTick];
+idxsametick =  diff(  [(systemTicks(1)-1) systemTicks] ) == 0;
+TDdat.AccelData = TDdat.AccelData(~idxsametick);
+
+
+
+
+
+
+%% deduce sampling rate 
+srates = getSampleRateAcc([TDdat.AccelData.SampleRate]');
+
+%% pre allocate memory 
+% find out how many channels of data you have 
+nchan = 3; % you always get 3 channels 
+% find out how many rows you need to allocate 
+tmp = [TDdat.AccelData.Header];
+datasizes = [tmp.dataSize]';
+% xxxxxxxxx
+packetsizes = (datasizes/8); % divide by 8 for now, this may need to be fixed 
+% xxxxxxxxx
+nrows = sum(packetsizes);
+outdat = zeros(nrows, nchan+2); % pre allocate memory 
+
+%% loop on pacets to create out data with INS time and system tick 
+% loop on packets and populate packets fields 
+start = tic; 
+curidx = 0; 
+for p = 1:size(datasizes,1)
+    rowidx = curidx+1:1:(packetsizes(p)+curidx);
+    curidx = curidx + packetsizes(p); 
+    packetidx = curidx;  % the time is always associated with the last sample in the packet 
+    outdat(rowidx,1) = TDdat.AccelData(p).XSamples;
+    varnames{1} = 'XSamples';
+    outdat(rowidx,2) = TDdat.AccelData(p).YSamples;
+    varnames{2} = 'YSamples';
+    outdat(rowidx,3) = TDdat.AccelData(p).ZSamples;
+    varnames{3} = 'ZSamples';
+    outdat(packetidx,nchan+1) = TDdat.AccelData(p).Header.systemTick; 
+    varnames{nchan+1} = 'systemTick'; 
+    outdat(packetidx,nchan+2) = TDdat.AccelData(p).Header.timestamp.seconds; 
+    varnames{nchan+2} = 'timestamp'; 
+    outdat(packetidx,nchan+3) = TDdat.AccelData(p).PacketGenTime;
+    varnames{nchan+3} = 'PacketGenTime'; 
+    outdat(packetidx,nchan+4) = TDdat.AccelData(p).PacketRxUnixTime;
+    varnames{nchan+4} = 'PacketRxUnixTime'; 
+    outdat(packetidx,nchan+5) = packetsizes(p);
+    varnames{nchan+5} = 'packetsizes'; 
+end
+%%
+fprintf('finished unpacking into matrix in %.2f seconds\n',toc(start));
+outtable = array2table(outdat);
+clear outdat; 
+outtable.Properties.VariableNames = varnames; 
+outtable.Properties.VariableDescriptions{nchan+1} = ...
+    'systemTick ? INS clock-driven tick counter, 16bits, LSB is 100microseconds, (highly accurate, high resolution, rolls over)';
+outtable.Properties.VariableDescriptions{nchan+2} = ...
+    'timestamp ? INS clock-driven time, LSB is seconds (highly accurate, low resolution, does not roll over)';
+
+end

--- a/code/createAccelTable.m
+++ b/code/createAccelTable.m
@@ -1,198 +1,50 @@
-function [outtable, srates] = createAccelTable(TDdat)
-%% Function to unravel TimeDomainData
-% input: a structure time domain data that is read from TimeDomainRaw.json 
-% file that is spit out by RC+S Summit interface. 
-% To transform *.json file into structure use deserializeJSON.m 
-% in this folder 
-%% unravel data 
+function [outtable, srates] = createAccelTable(jsonobj_Accel)
+%% Function to unravel Accelerometer data
+% Input: a structure of accelerometer data that is read from RawDataAccel.json
+% To transform *.json file into structure use deserializeJSON.m
+%%
+% Extract sampling rate
+srates = getSampleRateAcc([jsonobj_Accel.AccelData.SampleRate]');
 
+%%
+% Calculate number of samples
+tmp = [jsonobj_Accel.AccelData.Header];
+dataSizes = [tmp.dataSize]';
+packetSizes = (dataSizes/8); % divide by 8 for now, this may need to be fixed
+nrows = sum(packetSizes);
 
+allVarNames = {'XSamples','YSamples','ZSamples','systemTick','timestamp','PacketGenTime',...
+    'PacketRxUnixTime','packetsizes','dataTypeSequence'};
+% Pre allocate memory
+outdat = zeros(nrows, length(allVarNames));
 
-%% check for bad packets 
-
-unixtimes = [TDdat.AccelData.PacketRxUnixTime];
-uxtimes = datetime(unixtimes'/1000,...
-    'ConvertFrom','posixTime','TimeZone','America/Los_Angeles','Format','dd-MMM-yyyy HH:mm:ss.SSS');
-
-temp  = [TDdat.AccelData.Header];
-temp2 = [temp.timestamp];
-uxseconds = [temp2.seconds];
-startTimeDt = datetime(datevec(uxseconds./86400 + datenum(2000,3,1,0,0,0))); % medtronic time - LSB is seconds
-
-yearMode = mode(year(startTimeDt)); 
-
-
-
-
-% check for packets with funky year 
-badPackets = year(startTimeDt)~=yearMode;  % sometimes the seconds is a bad msseaurment 
-% evidnetly year is not hte only problem, make sure most packets within a
-% week of median (to take care of cases in which reconnecitons happen
-% throughout days) 
-medianTime = median(startTimeDt);
-badPackets3 = startTimeDt > (medianTime + hours(24)*7);
-badPackets4= startTimeDt < (medianTime - hours(24)*7);
-% check for packets in the future 
-badPackets2 = uxtimes(1:end-1) >= uxtimes(2:end) ;
-badPackets2 = [badPackets2; 0];
-% check to see if packet time can be negative 
-badpackets5 = [TDdat.AccelData.PacketGenTime]<=0;
-badpackets5 = badpackets5';
-% check to see if data type sequence always increases monotonically 
-% note that it roles over after 255 packets (e.g. goes from 255 to 0). 
-% I am getting rid of the first packet on purpose 
-headertemp = TDdat.AccelData;
-headers2 = [headertemp.Header];
-dataTypeSequence = [headers2.dataTypeSequence];
-dataTypeSequenceTemp = [headers2(1).dataTypeSequence dataTypeSequence];
-badpackets6 = diff(dataTypeSequenceTemp')==0;
-
-
-idxBadPackets = badPackets | badPackets2 | badPackets3 | badPackets4 | badpackets5 | badpackets6 ;
-TDdat.AccelData = TDdat.AccelData(~idxBadPackets);
-
-
-
-% find ambigous roleovers and remove them to make them not ambigous
-% any more 
-headertemp = TDdat.AccelData;
-headers2 = [headertemp.Header];
-temp = [headers2.timestamp];
-timestamps = [temp.seconds]; 
-timestamps_sec = datetime(datevec(timestamps./86400 + datenum(2000,3,1,0,0,0)),...% medtronic time - LSB is seconds
-    'TimeZone','America/Los_Angeles','Format','dd-MMM-yyyy HH:mm:ss.SSS'); 
-idxGapsLargerThan6sec = find(seconds(diff([timestamps_sec(1); timestamps_sec])) > 6);
-max_st = (2^16)/1e4; 
-cnt = 1;
-bad_timestamps = NaT;
-bad_timestamps.TimeZone = timestamps_sec.TimeZone;
-for i = 1:length( idxGapsLargerThan6sec ) 
-    ts1 = timestamps_sec(idxGapsLargerThan6sec(i)-1); 
-    ts2 = timestamps_sec(idxGapsLargerThan6sec(i)); 
-    curgap = ts2-ts1; 
-    % is the gap potentially ambgious
-    minN = seconds(ts2 - (ts1 + seconds(1))) / max_st;
-    maxN = seconds((ts2+ seconds(1)) - ts1) / max_st;
-    % if the gap can be ambigous remove packets until it is not
-    if floor(minN) ~= floor(maxN) 
-        minN_new = minN; 
-        maxN_new = maxN; 
-        
-        ts2_new = ts2;
-        ts1_new = ts1;
-
-         while minN_new ~= maxN_new
-             minN_new = floor( seconds(ts2_new - (ts1_new + seconds(1))) / max_st );
-             maxN_new = floor( seconds((ts2_new+ seconds(1)) - ts1_new) / max_st  );
-             bad_timestamps(cnt) = ts2_new;
-             ts2_new = ts2_new + seconds(1);
-             cnt = cnt +1 ;
-         end
-         fprintf('[%0.3d] current gap is %s secs\n',i,ts2_new-ts1_new);
-         fprintf('\t ts1   - %s\t ts2   - %s\n',ts1,ts2);
-         fprintf('\t ts1_n - %s\t ts2_n - %s\n',ts1_new,ts2_new);
-    else
-        fprintf('[%0.3d] current gap is not ambigous - %s secs\n',i,ts2-ts1);
-                 fprintf('\t ts1   - %s\t ts2   - %s\n',ts1,ts2);
-
-    end
-end
-idx_bad_timetamps = [];
-for b = 1:length(bad_timestamps)
-    idx_bad_timetamps = [idx_bad_timetamps; find(timestamps_sec == bad_timestamps(b) )];
-end
-idxkeep = setxor(1:size(TDdat.AccelData,2),idx_bad_timetamps);
-
-% repot on the gaps before and after the changes 
-systemTicks = [headers2.systemTick];
-for i = 1:length(idxGapsLargerThan6sec)
-    fprintf('[%0.2d]\t previous = %s\t \t%d  current = %s\t %d\t \n',...
-        i,timestamps_sec(idxGapsLargerThan6sec(i) - 1),systemTicks(idxGapsLargerThan6sec(i)-1)',...
-        timestamps_sec(idxGapsLargerThan6sec(i)),systemTicks(idxGapsLargerThan6sec(i))')
-end
-TDdat.AccelData = TDdat.AccelData(idxkeep);
-
-
-headertemp = TDdat.AccelData;
-headers2 = [headertemp.Header];
-temp = [headers2.timestamp];
-systemTicks = [headers2.systemTick];
-timestamps = [temp.seconds]; 
-timestamps_sec = datetime(datevec(timestamps./86400 + datenum(2000,3,1,0,0,0)),...% medtronic time - LSB is seconds
-    'TimeZone','America/Los_Angeles','Format','dd-MMM-yyyy HH:mm:ss.SSS'); 
-idxGapsLargerThan6sec = find(seconds(diff([timestamps_sec(1); timestamps_sec])) > 6);
-for i = 1:length(idxGapsLargerThan6sec)
-    fprintf('[%0.2d]\t previous = %s\t \t%d  current = %s\t %d\t \n',...
-        i,timestamps_sec(idxGapsLargerThan6sec(i) - 1),systemTicks(idxGapsLargerThan6sec(i)-1)',...
-        timestamps_sec(idxGapsLargerThan6sec(i)),systemTicks(idxGapsLargerThan6sec(i))')
+%%
+% Loop through packets to populate fields
+start = tic;
+currentIndex = 0;
+for p = 1:size(dataSizes,1)
+    rowidx = currentIndex + 1:(packetSizes(p)+currentIndex);
+    currentIndex = currentIndex + packetSizes(p);
+    packetidx = currentIndex;  % the time is always associated with the last sample in the packet
+    outdat(rowidx, 1) = jsonobj_Accel.AccelData(p).XSamples;
+    outdat(rowidx, 2) = jsonobj_Accel.AccelData(p).YSamples;
+    outdat(rowidx, 3) = jsonobj_Accel.AccelData(p).ZSamples;
+    outdat(packetidx, 4) = jsonobj_Accel.AccelData(p).Header.systemTick;
+    outdat(packetidx, 5) = jsonobj_Accel.AccelData(p).Header.timestamp.seconds;
+    outdat(packetidx, 6) = jsonobj_Accel.AccelData(p).PacketGenTime;
+    outdat(packetidx, 7) = jsonobj_Accel.AccelData(p).PacketRxUnixTime;
+    outdat(packetidx, 8) = packetSizes(p);
+    outdat(packetidx, 9) = jsonobj_Accel.AccelData(p).Header.dataTypeSequence;
 end
 
-
-
-% remove system ticks that are the same - this is essentially a duplicate
-% packet, remove the second one 
-% there is a small chance we are removing a roleover event (e.g. large
-% packet loss, but even in these cases it would make it much easier to
-% compute if we didn't have this packet). 
-headertemp = TDdat.AccelData;
-headers2 = [headertemp.Header];
-systemTicks = [headers2.systemTick];
-idxsametick =  diff(  [(systemTicks(1)-1) systemTicks] ) == 0;
-TDdat.AccelData = TDdat.AccelData(~idxsametick);
-
-
-
-
-
-
-%% deduce sampling rate 
-srates = getSampleRateAcc([TDdat.AccelData.SampleRate]');
-
-%% pre allocate memory 
-% find out how many channels of data you have 
-nchan = 3; % you always get 3 channels 
-% find out how many rows you need to allocate 
-tmp = [TDdat.AccelData.Header];
-datasizes = [tmp.dataSize]';
-% xxxxxxxxx
-packetsizes = (datasizes/8); % divide by 8 for now, this may need to be fixed 
-% xxxxxxxxx
-nrows = sum(packetsizes);
-outdat = zeros(nrows, nchan+2); % pre allocate memory 
-
-%% loop on pacets to create out data with INS time and system tick 
-% loop on packets and populate packets fields 
-start = tic; 
-curidx = 0; 
-for p = 1:size(datasizes,1)
-    rowidx = curidx+1:1:(packetsizes(p)+curidx);
-    curidx = curidx + packetsizes(p); 
-    packetidx = curidx;  % the time is always associated with the last sample in the packet 
-    outdat(rowidx,1) = TDdat.AccelData(p).XSamples;
-    varnames{1} = 'XSamples';
-    outdat(rowidx,2) = TDdat.AccelData(p).YSamples;
-    varnames{2} = 'YSamples';
-    outdat(rowidx,3) = TDdat.AccelData(p).ZSamples;
-    varnames{3} = 'ZSamples';
-    outdat(packetidx,nchan+1) = TDdat.AccelData(p).Header.systemTick; 
-    varnames{nchan+1} = 'systemTick'; 
-    outdat(packetidx,nchan+2) = TDdat.AccelData(p).Header.timestamp.seconds; 
-    varnames{nchan+2} = 'timestamp'; 
-    outdat(packetidx,nchan+3) = TDdat.AccelData(p).PacketGenTime;
-    varnames{nchan+3} = 'PacketGenTime'; 
-    outdat(packetidx,nchan+4) = TDdat.AccelData(p).PacketRxUnixTime;
-    varnames{nchan+4} = 'PacketRxUnixTime'; 
-    outdat(packetidx,nchan+5) = packetsizes(p);
-    varnames{nchan+5} = 'packetsizes'; 
-end
 %%
 fprintf('finished unpacking into matrix in %.2f seconds\n',toc(start));
 outtable = array2table(outdat);
-clear outdat; 
-outtable.Properties.VariableNames = varnames; 
-outtable.Properties.VariableDescriptions{nchan+1} = ...
+clear outdat;
+outtable.Properties.VariableNames = allVarNames;
+outtable.Properties.VariableDescriptions{4} = ...
     'systemTick ? INS clock-driven tick counter, 16bits, LSB is 100microseconds, (highly accurate, high resolution, rolls over)';
-outtable.Properties.VariableDescriptions{nchan+2} = ...
+outtable.Properties.VariableDescriptions{5} = ...
     'timestamp ? INS clock-driven time, LSB is seconds (highly accurate, low resolution, does not roll over)';
 
 end

--- a/code/createTimeDomainTable.m
+++ b/code/createTimeDomainTable.m
@@ -1,0 +1,66 @@
+function [outtable, srates] = createTimeDomainTable(TDdat)
+%% Function to unravel TimeDomainData
+% Input: a structure time domain data that is read from RawDataTD.json
+% To transform *.json file into structure use deserializeJSON.m
+
+% Extract sampling rates
+srates = getSampleRate([TDdat.TimeDomainData.SampleRate]');
+
+% Determine number of channels per packet
+tdtmp = TDdat.TimeDomainData;
+for p = 1:size(tdtmp,2)
+    nChans(p,1) = size(tdtmp(p).ChannelSamples,2);
+end
+
+% Determine number of samples per packet
+tmp = [TDdat.TimeDomainData.Header];
+dataSizes = [tmp.dataSize]';
+packetSizes = (dataSizes./nChans)./2; % divide by 2 bcs data Size is number of bits in packet.
+
+% Pre allocate matrix
+maxNumChans = 4; % For simplicity, always initialize for 4 chans
+nrows = sum(packetSizes);
+allVarNames = {'key0','key1','key2','key3','systemTick','timestamp',...
+    'samplerate','PacketGenTime','PacketRxUnixTime','packetsizes',...
+    'dataTypeSequence'};
+outdat = zeros(nrows, length(allVarNames)); % pre allocate memory
+
+% Loop through packets to populate  fields
+start = tic;
+currentIndex = 0;
+
+for p = 1:size(dataSizes,1)
+    rowidx = currentIndex + 1:(packetSizes(p) + currentIndex);
+    currentIndex = currentIndex + packetSizes(p);
+    packetidx = currentIndex;  % the time is always associated with the last sample in the packet
+    samples = TDdat.TimeDomainData(p).ChannelSamples;
+    nchan =  nChans(p,1);
+    for c = 1:size(samples,2)
+        idxuse = samples(c).Key+1;% bcs keys (channels) are zero indexed
+        outdat(rowidx,idxuse) = samples(c).Value;
+    end
+    outdat(packetidx,5) = TDdat.TimeDomainData(p).Header.systemTick;
+    outdat(packetidx,6) = TDdat.TimeDomainData(p).Header.timestamp.seconds;
+    outdat(packetidx,7) = srates(p);
+    outdat(packetidx,8) = TDdat.TimeDomainData(p).PacketGenTime;
+    outdat(packetidx,9) = TDdat.TimeDomainData(p).PacketRxUnixTime;
+    outdat(packetidx,10) = packetSizes(p);
+    outdat(packetidx,11) = TDdat.TimeDomainData(p).Header.dataTypeSequence;
+end
+
+%%
+fprintf('finished unpacking into matrix in %.2f seconds\n',toc(start));
+outtable = array2table(outdat);
+clear outdat;
+outtable.Properties.VariableNames = allVarNames;
+outtable.Properties.VariableDescriptions{5} = ...
+    'systemTick ? INS clock-driven tick counter, 16bits, LSB is 100microseconds, (highly accurate, high resolution, rolls over)';
+outtable.Properties.VariableDescriptions{6} = ...
+    'timestamp ? INS clock-driven time, LSB is seconds (highly accurate, low resolution, does not roll over)';
+outtable.Properties.VariableDescriptions{7} = ...
+    'sample rate for each packet, used in cases in which the sample rate is not conssistent through out session';
+outtable.Properties.VariableDescriptions{8} = ...
+    'API estimate of when the data packet was created on the INS within the PC clock domain. Estimate created by using results of latest latency check (one is done at system initialization, but can re-perform whenever you want) and time sync streaming. Potentially useful for syncing with other sensors or devices by bringing things into the PC clock domain, but is only accurate within 50ms give or take.';
+outtable.Properties.VariableDescriptions{9} = ...
+    'PC clock-driven time when the packet was received via Bluetooth, as accurate as a C# DateTime.now (10-20ms)';
+end

--- a/code/deserializeJSON.m
+++ b/code/deserializeJSON.m
@@ -1,0 +1,46 @@
+function data = deserializeJSON(filename)
+%%
+% Reads .JSON files from RC+S and loads data into Matlab. In cases where
+% end closing brackets is missing, will add in order to make file readable.
+% Requires turtle_json toolbox
+%%
+
+% Add turtle_json toolbox to path
+pathToCode = mfilename('fullpath');
+filePath = fileparts(pathToCode);
+addpath(genpath(fullfile(filePath,'toolboxes', 'turtle_json','src')))
+
+% Try loading json file - may need to have a closing bracket added
+start = tic;
+try
+    data = json.load(filename);
+    fprintf('File loaded in %.2f seconds\n',toc(start));
+catch
+    warning('Not able to open file - attmepting fix');
+    fprintf('Defective file %s\n',filename);
+    
+    % Try to fix the file; separate fixes for Adaptive vs all other JSON
+    % file types
+    dat = fileread(filename);
+    [~,jsonFileName,~] = fileparts(filename);
+    
+    if strcmp(jsonFileName,'AdaptiveLog')
+        adaptiveFile = filename;
+        data = jsondecode(fixMalformedJson(fileread(adaptiveFile),'AdaptiveLog'));
+    else
+        if strcmp(dat(end),'}')  % it's missing the end closing brackets
+            fileID = fopen(filename,'a');
+            fprintf(fileID,'%s',']}]');
+            fclose(fileID);
+            try
+                data = json.load(filename);
+                fprintf('File loaded in %.2f seconds\n',toc(start));
+            catch
+                fprintf('File failed to load problem with json\n');
+                data = [];
+            end
+        end
+    end
+end
+
+end

--- a/code/fixMalformedJson.m
+++ b/code/fixMalformedJson.m
@@ -1,0 +1,21 @@
+function [ jsonStringOut ] = fixMalformedJson( jsonString, type )
+
+jsonString = strrep(jsonString,'INF','Inf'); % change inproper infinite labels
+
+numOpenSqua = size(find(jsonString=='['),2);
+numOpenCurl = size(find(jsonString=='{'),2);
+numCloseCurl = size(find(jsonString=='}'),2);
+numCloseSqua = size(find(jsonString==']'),2);
+
+%Perform JSON formating fix depending on the file type.
+if numOpenSqua~=numCloseSqua && (contains(type,'Log') || contains(type,'Settings'))
+    jsonStringOut = strcat(jsonString,']'); % add missing bracket to the end
+    disp('Your .json file appears to be malformed, a fix was attempted in order to proceed with processing')
+elseif numOpenSqua~=numCloseSqua || numOpenCurl~=numCloseCurl
+    %Put Fix here for adding in missing brackets at the end of the file.  Assume I want all curls, then all squares, and always end with }]
+    jsonStringfix = strcat(repmat('}',1,(numOpenCurl-numCloseCurl-1)),repmat(']',1,(numOpenSqua-numCloseSqua-1)),'}]');
+    jsonStringOut = strcat(jsonString,jsonStringfix);
+    disp('Your .json file appears to be malformed, a fix was attempted in order to proceed with processing') 
+else
+    jsonStringOut = jsonString;
+end

--- a/code/getSampleRate.m
+++ b/code/getSampleRate.m
@@ -28,4 +28,4 @@ sratesout(srates==1) = 500;
 sratesout(srates==2) = 1000;
 
 
-clear temp*; 
+end

--- a/code/getSampleRate.m
+++ b/code/getSampleRate.m
@@ -1,19 +1,24 @@
 function sratesout = getSampleRate(srates)
-%% input: matrix of sample rates of each packet from TimeDomainData.Json 
-%% output: sample rate in Hz 
+%%
+% Input: Vector of sample rates of each packet from RawDataTD.json
+% (Vector of the 'SampleRate' column, after having imported json
+% into Matlab table). Typical workflow is to call this function from
+% createTimeDomainTable.m. 
+%
+% Output: sample rate in Hz
+%%
 
-
-if length(unique(srates)) > 1 
-    warning('you have non uniform sample rates in your data'); 
+if length(unique(srates)) > 1
+    warning('you have non uniform sample rates in your data');
 else
-    sratenum = unique(srates); 
-    switch sratenum 
-        case 0 
-            srate = 250; % sample rate in Hz. 
-        case 1 
-            srate = 500; 
-        case 2 
-            srate = 1e3; 
+    sratenum = unique(srates);
+    switch sratenum
+        case 0
+            srate = 250; % sample rate in Hz.
+        case 1
+            srate = 500;
+        case 2
+            srate = 1e3;
     end
 end
 fprintf('out of %d packets:\n\t%d packets at 250Hz\n\t%d packets at 500Hz\n \t%d packets at 1000Hz\n',...
@@ -21,8 +26,8 @@ fprintf('out of %d packets:\n\t%d packets at 250Hz\n\t%d packets at 500Hz\n \t%d
     sum((srates==0)),...
     sum((srates==1)),...
     sum((srates==2)));
-% make sample rates numbers 
-sratesout = srates; 
+% make sample rates numbers
+sratesout = srates;
 sratesout(srates==0) = 250;
 sratesout(srates==1) = 500;
 sratesout(srates==2) = 1000;

--- a/code/getSampleRate.m
+++ b/code/getSampleRate.m
@@ -1,0 +1,31 @@
+function sratesout = getSampleRate(srates)
+%% input: matrix of sample rates of each packet from TimeDomainData.Json 
+%% output: sample rate in Hz 
+
+
+if length(unique(srates)) > 1 
+    warning('you have non uniform sample rates in your data'); 
+else
+    sratenum = unique(srates); 
+    switch sratenum 
+        case 0 
+            srate = 250; % sample rate in Hz. 
+        case 1 
+            srate = 500; 
+        case 2 
+            srate = 1e3; 
+    end
+end
+fprintf('out of %d packets:\n\t%d packets at 250Hz\n\t%d packets at 500Hz\n \t%d packets at 1000Hz\n',...
+    length(srates),...
+    sum((srates==0)),...
+    sum((srates==1)),...
+    sum((srates==2)));
+% make sample rates numbers 
+sratesout = srates; 
+sratesout(srates==0) = 250;
+sratesout(srates==1) = 500;
+sratesout(srates==2) = 1000;
+
+
+clear temp*; 

--- a/code/getSampleRateAcc.m
+++ b/code/getSampleRateAcc.m
@@ -1,0 +1,28 @@
+function sratesout = getSampleRateAcc(srates)
+%% input: matrix of sample rates of each packet from TimeDomainData.Json 
+%% output: sample rate in Hz 
+
+
+if length(unique(srates)) > 1 
+    warning('you have non uniform sample rates in your data'); 
+end
+
+
+
+
+fprintf('out of %d packets:\n\t%d packets at 250Hz\n\t%d packets at 500Hz\n \t%d packets at 1000Hz\n',...
+    length(srates),...
+    sum((srates==0)),...
+    sum((srates==1)),...
+    sum((srates==2)));
+
+% make sample rates numbers 
+sratesout = srates; 
+sratesout(srates==0) = 64;
+sratesout(srates==1) = 32;
+sratesout(srates==2) = 16;
+sratesout(srates==3) = 8;
+sratesout(srates==4) = 4;
+sratesout(srates==255) = NaN;
+
+clear temp*; 

--- a/code/getSampleRateAcc.m
+++ b/code/getSampleRateAcc.m
@@ -17,4 +17,4 @@ sratesout(srates==3) = 8;
 sratesout(srates==4) = 4;
 sratesout(srates==255) = NaN;
 
-clear temp*; 
+end 

--- a/code/getSampleRateAcc.m
+++ b/code/getSampleRateAcc.m
@@ -1,22 +1,14 @@
 function sratesout = getSampleRateAcc(srates)
-%% input: matrix of sample rates of each packet from TimeDomainData.Json 
-%% output: sample rate in Hz 
-
+%%
+% Input: matrix of sample rates of each packet from RawDataAccel.Json 
+% Output: sample rate in Hz 
+%%
 
 if length(unique(srates)) > 1 
     warning('you have non uniform sample rates in your data'); 
 end
 
-
-
-
-fprintf('out of %d packets:\n\t%d packets at 250Hz\n\t%d packets at 500Hz\n \t%d packets at 1000Hz\n',...
-    length(srates),...
-    sum((srates==0)),...
-    sum((srates==1)),...
-    sum((srates==2)));
-
-% make sample rates numbers 
+% Convert sample rate codes to Hz
 sratesout = srates; 
 sratesout(srates==0) = 64;
 sratesout(srates==1) = 32;


### PR DESCRIPTION
Function for creating `derivedTime` for each sample. Compatible with TimeDomain and Accelerometer data. Input to this function is the output of `createTimeDomainTable` or `createAccelTable`